### PR TITLE
feat: replace redux-persist with redux-remember

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-hook-form": "7.87.0",
     "react-redux": "9.3.0",
     "react-router-dom": "7.18.3",
-    "redux-persist": "6.0.0",
+    "redux-remember": "^6.0.2",
     "zod": "4.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,9 @@ importers:
       react-router-dom:
         specifier: 7.18.3
         version: 7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      redux-persist:
-        specifier: 6.0.0
-        version: 6.0.0(react@19.2.8)(redux@5.0.1)
+      redux-remember:
+        specifier: ^6.0.2
+        version: 6.0.2(redux@5.0.1)
       zod:
         specifier: 4.5.4
         version: 4.5.4
@@ -3795,14 +3795,10 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
-  redux-persist@6.0.0:
-    resolution: {integrity: sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==}
+  redux-remember@6.0.2:
+    resolution: {integrity: sha512-Y5zvPujEEGYQMSJmODp3NjSj4BiXTHflhRs82btK/cHOwrJNh2CEVIBGlPTMRG6Pos3+Eea7M3vzhegEBFd0Lg==}
     peerDependencies:
-      react: '>=16'
-      redux: '>4.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
+      redux: '>=5.0.0'
 
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
@@ -8175,11 +8171,9 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  redux-persist@6.0.0(react@19.2.8)(redux@5.0.1):
+  redux-remember@6.0.2(redux@5.0.1):
     dependencies:
       redux: 5.0.1
-    optionalDependencies:
-      react: 19.2.8
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:

--- a/src/app/appEntry.tsx
+++ b/src/app/appEntry.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 import { Provider as ModalProvider } from '@ebay/nice-modal-react'
 import ReactDOM from 'react-dom/client'
 import { Provider as ReduxProvider } from 'react-redux'
-import { PersistGate } from 'redux-persist/integration/react'
 import { ThemeProvider } from '@/entities/theme'
 import '@/shared/base.css'
-import { appStore, persistedStore } from '@/shared/redux'
+import { appStore } from '@/shared/redux'
 import { DebugModeProvider } from '@/widgets/Layout'
 import { RouterProvider } from './with-providers/router/RouterProvider'
 
@@ -31,13 +30,11 @@ initApp().then(() => {
     <React.StrictMode>
       <ModalProvider>
         <ReduxProvider store={appStore}>
-          <PersistGate loading={null} persistor={persistedStore}>
-            <ThemeProvider>
-              <DebugModeProvider>
-                <RouterProvider />
-              </DebugModeProvider>
-            </ThemeProvider>
-          </PersistGate>
+          <ThemeProvider>
+            <DebugModeProvider>
+              <RouterProvider />
+            </DebugModeProvider>
+          </ThemeProvider>
         </ReduxProvider>
       </ModalProvider>
     </React.StrictMode>,

--- a/src/app/storybookDecorators/withStore.tsx
+++ b/src/app/storybookDecorators/withStore.tsx
@@ -5,7 +5,7 @@ import { env } from '@/shared/lib'
 import { makeStore } from '@/shared/redux'
 import { toggleDebugMode } from '@/widgets/Layout'
 
-const store = makeStore()
+const store = makeStore({ persisted: false })
 
 store.dispatch(
   loginThunk({

--- a/src/entities/session/model/slice.ts
+++ b/src/entities/session/model/slice.ts
@@ -1,6 +1,5 @@
-import type { PayloadAction, WithSlice } from '@reduxjs/toolkit'
+import type { WithSlice } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
-import { REHYDRATE } from 'redux-persist'
 import { rootReducer } from '@/shared/redux'
 import { sessionApi } from '../api/sessionApi'
 import type { SessionUserId } from './types'
@@ -36,16 +35,6 @@ const slice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    // Restore state from redux-persist
-    builder.addCase(REHYDRATE, (state, action) => {
-      const typedAction = action as PayloadAction<{ session: SessionSliceState }>
-      if (typedAction.payload?.session) {
-        state.isAuthorized = typedAction.payload.session.isAuthorized as false
-        state.userId = typedAction.payload.session.userId
-        state.accessToken = typedAction.payload.session.accessToken
-      }
-    })
-
     builder.addMatcher(
       sessionApi.endpoints.login.matchFulfilled,
       (state: SessionSliceState, { payload }) => {

--- a/src/entities/theme/model/slice.ts
+++ b/src/entities/theme/model/slice.ts
@@ -1,6 +1,5 @@
 import type { PayloadAction, WithSlice } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
-import { REHYDRATE } from 'redux-persist'
 import { rootReducer } from '@/shared/redux'
 import type { Theme } from './types'
 
@@ -24,15 +23,6 @@ const slice = createSlice({
     toggle: (state, action: PayloadAction<Theme>) => {
       state.currentTheme = action.payload
     },
-  },
-  extraReducers: (builder) => {
-    // Restore state from redux-persist
-    builder.addCase(REHYDRATE, (state, action) => {
-      const typedAction = action as PayloadAction<{ theme: ThemeSliceState }>
-      if (typedAction.payload?.theme) {
-        state.currentTheme = typedAction.payload.theme.currentTheme
-      }
-    })
   },
 })
 

--- a/src/shared/redux/index.ts
+++ b/src/shared/redux/index.ts
@@ -7,7 +7,7 @@ export { useAppDispatch } from './lib/useAppDispatch'
 export { useAppSelector } from './lib/useAppSelector'
 export { rootReducer } from './model/rootReducer'
 export type { AppDispatch, AppState } from './model/store'
-export { appStore, persistedStore } from './model/store'
+export { appStore } from './model/store'
 export { makeStore } from './model/store'
 export type { LazyLoadedReduxSlices } from './model/types'
 

--- a/src/shared/redux/model/store.ts
+++ b/src/shared/redux/model/store.ts
@@ -1,39 +1,28 @@
 import { configureStore, createDynamicMiddleware } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query'
-import {
-  FLUSH,
-  PAUSE,
-  PERSIST,
-  persistReducer,
-  persistStore,
-  PURGE,
-  REGISTER,
-  REHYDRATE,
-} from 'redux-persist'
-import storage from 'redux-persist/lib/storage'
+import { rememberEnhancer, rememberReducer } from 'redux-remember'
 import { rootReducer } from './rootReducer'
 
 export const dynamicMiddleware = createDynamicMiddleware()
 
-const persistConfig = {
-  key: 'root',
-  storage,
-  whitelist: ['session', 'theme', 'debugMode'],
+const rememberedKeys = ['session', 'theme', 'debugMode']
+
+type MakeStoreOptions = {
+  // Persist store to localStorage (disable for storybook/test stores)
+  persisted?: boolean
 }
 
-export function makeStore() {
+export function makeStore({ persisted = true }: MakeStoreOptions = {}) {
   const store = configureStore({
-    reducer: persistReducer(
-      persistConfig,
-      rootReducer,
-    // FIXME: persistReducer broke types, so force cast it to rootReducer
-    ) as unknown as typeof rootReducer,
+    reducer: rememberReducer(rootReducer),
     middleware: getDefaultMiddleware =>
-      getDefaultMiddleware({
-        serializableCheck: {
-          ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
-        },
-      }).concat(dynamicMiddleware.middleware),
+      getDefaultMiddleware().concat(dynamicMiddleware.middleware),
+    enhancers: getDefaultEnhancers =>
+      persisted
+        ? getDefaultEnhancers().concat(
+            rememberEnhancer(window.localStorage, rememberedKeys),
+          )
+        : getDefaultEnhancers(),
   })
 
   setupListeners(store.dispatch)
@@ -42,7 +31,6 @@ export function makeStore() {
 }
 
 export const appStore = makeStore()
-export const persistedStore = persistStore(appStore)
 
 export type AppState = ReturnType<typeof appStore.getState>
 export type AppDispatch = typeof appStore.dispatch

--- a/src/widgets/Layout/model/debugModeSlice.ts
+++ b/src/widgets/Layout/model/debugModeSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
-import type { PayloadAction, WithSlice } from '@reduxjs/toolkit'
-import { REHYDRATE } from 'redux-persist'
+import type { WithSlice } from '@reduxjs/toolkit'
 import { rootReducer } from '@/shared/redux'
 
 type DebugModeSlice = {
@@ -23,15 +22,6 @@ const slice = createSlice({
     toggle: (state) => {
       state.isEnabled = !state.isEnabled
     },
-  },
-  extraReducers: (builder) => {
-    // Restore state from redux-persist
-    builder.addCase(REHYDRATE, (state, action) => {
-      const typedAction = action as PayloadAction<{ debugMode: DebugModeSlice }>
-      if (typedAction.payload?.debugMode) {
-        state.isEnabled = typedAction.payload.debugMode.isEnabled
-      }
-    })
   },
 })
 


### PR DESCRIPTION
## Why

- redux-persist is unmaintained (last release in 2019, 584 open issues), while RTK maintainer endorses `redux-remember` as the replacement
- Net −52 lines: no `PersistGate`, no `FIXME` type cast, no `serializableCheck` ignores, no manual `REHYDRATE` handlers in slices

## What has changed

- `src/shared/redux/model/store.ts`: `persistReducer`/`persistStore` → `rememberReducer` + `rememberEnhancer` (localStorage driver, same whitelist: `session`, `theme`, `debugMode`); `makeStore({ persisted })` option added so the Storybook store doesn't write to localStorage
- `src/app/appEntry.tsx`: `PersistGate` removed — redux-remember rehydrates into the reducer, no gate needed
- Slices (`session`, `theme`, `debugMode`): manual `REHYDRATE` extraReducers removed — rehydration is handled by `rememberReducer` state replacement
- Removed `persistedStore` export and the redux-persist dependency entirely

## Notes

- Storage format changed: redux-remember stores one key per slice (`@@remember-<key>`) instead of redux-persist's `persist:root`. Old `persist:root` data is ignored, so users' persisted theme/session/debugMode reset once. Add a one-time migration from `persist:root` if this matters
- Per RTK docs, RTK Query cache is not persisted (none was whitelisted anyway)
