### PR TITLE
chore: use vite native tsconfig paths and import.meta.dirname

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,7 @@
     "ts-to-zod": "5.1.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "8.2.2",
-    "vite-plugin-svgr": "5.2.0",
-    "vite-tsconfig-paths": "6.1.1"
+    "vite-plugin-svgr": "5.2.0"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
       vite-plugin-svgr:
         specifier: 5.2.0
         version: 5.2.0(@typescript/typescript6@6.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(sugarss@5.0.1(postcss@8.5.26))(yaml@2.9.0))
-      vite-tsconfig-paths:
-        specifier: 6.1.1
-        version: 6.1.1(@typescript/typescript6@6.0.2)(supports-color@8.1.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(sugarss@5.0.1(postcss@8.5.26))(yaml@2.9.0))
 
 packages:
 
@@ -4362,11 +4359,6 @@ packages:
     resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
     peerDependencies:
       vite: '>=3.0.0'
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
@@ -8774,16 +8766,6 @@ snapshots:
       vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(sugarss@5.0.1(postcss@8.5.26))(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
-      - supports-color
-      - typescript
-
-  vite-tsconfig-paths@6.1.1(@typescript/typescript6@6.0.2)(supports-color@8.1.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(sugarss@5.0.1(postcss@8.5.26))(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(@typescript/typescript6@6.0.2)
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(sugarss@5.0.1(postcss@8.5.26))(yaml@2.9.0)
-    transitivePeerDependencies:
       - supports-color
       - typescript
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -4,17 +4,16 @@ import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
 import type { PluginOption } from 'vite'
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react(),
-    tsconfigPaths(),
     process.env.ANALYZE && (visualizer({ gzipSize: true, open: true }) as PluginOption),
   ].filter(Boolean),
   resolve: {
-    alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
+    tsconfigPaths: true,
+    alias: [{ find: '@', replacement: path.resolve(import.meta.dirname, 'src') }],
   },
   css: {
     modules: {


### PR DESCRIPTION
## Why

- Vite 8 warns that the config uses features unsupported by the upcoming default `configLoader: 'native'` (`__dirname`), and that `vite-tsconfig-paths` can be replaced by the native `resolve.tsconfigPaths` option

## What has changed

- `vite.config.mts`: `__dirname` → `import.meta.dirname`; `vite-tsconfig-paths` plugin removed in favor of `resolve.tsconfigPaths: true` (the explicit `@` alias is kept as a fallback for non-TS resolvers like CSS)
- `vite-tsconfig-paths` dependency removed (net −20 lines in the config)
