### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Nukeapp — React SPA pet store demo (Vite, TypeScript, Redux Toolkit, MSW) structured with Feature-Sliced Design.
+
+Guidelines for contributions, checks, and AI agent conventions live in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) — read it before making changes.


### PR DESCRIPTION
## Why

- Provide a brief project overview and a single entry point (AGENTS.md) pointing AI agents to contribution conventions

## What has changed

- Added AGENTS.md with a one-paragraph project description and a link to .github/CONTRIBUTING.md