### PR TITLE
refactor: migrate from forked @mswjs/data to @msw/data v1.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ebay/nice-modal-react": "1.2.13",
     "@hookform/resolvers": "5.9.1",
-    "@mswjs/data": "github:noveogroup-amorgunov/mswjs-data#feat-persist",
+    "@msw/data": "^1.1.8",
     "@reduxjs/toolkit": "2.12.0",
     "classnames": "2.5.1",
     "jose": "6.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,9 @@ importers:
       '@hookform/resolvers':
         specifier: 5.9.1
         version: 5.9.1(@standard-schema/spec@1.1.0)(react-hook-form@7.87.0(react@19.2.8))(valibot@1.2.0(@typescript/typescript6@6.0.2))(zod@4.5.4)
-      '@mswjs/data':
-        specifier: github:noveogroup-amorgunov/mswjs-data#feat-persist
-        version: https://codeload.github.com/noveogroup-amorgunov/mswjs-data/tar.gz/7bfd31dd673ad7c19bb3ef0c841a59787adb2adf(@types/node@26.4.0)(@typescript/typescript6@6.0.2)(supports-color@8.1.1)
+      '@msw/data':
+        specifier: ^1.1.8
+        version: 1.1.8
       '@reduxjs/toolkit':
         specifier: 2.12.0
         version: 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
@@ -880,9 +880,8 @@ packages:
   '@mjackson/multipart-parser@0.6.3':
     resolution: {integrity: sha512-aQhySnM6OpAYMMG+m7LEygYye99hB1md/Cy1AFE0yD5hfNW+X4JDu7oNVY9Gc6IW8PZ45D1rjFLDIUdnkXmwrA==}
 
-  '@mswjs/data@https://codeload.github.com/noveogroup-amorgunov/mswjs-data/tar.gz/7bfd31dd673ad7c19bb3ef0c841a59787adb2adf':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/noveogroup-amorgunov/mswjs-data/tar.gz/7bfd31dd673ad7c19bb3ef0c841a59787adb2adf}
-    version: 0.12.0
+  '@msw/data@1.1.8':
+    resolution: {integrity: sha512-+kSNeBPNvHkr/84aIK2ddeef8ng62T8xAG1zof5z8lMNgGt/jVwoDsPs9cYUU2WV4T2fn22NFi0NasmTzW2mnA==}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -1700,12 +1699,6 @@ packages:
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
-  '@types/lodash@4.17.25':
-    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
-
-  '@types/md5@2.3.6':
-    resolution: {integrity: sha512-WD69gNXtRBnpknfZcb4TRQ0XJQbUPZcai/Qdhmka3sxUR3Et8NrXoeAoknG/LghYHTf4ve795rInVYHBTQdNVA==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1717,9 +1710,6 @@ packages:
 
   '@types/node@26.4.0':
     resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
-
-  '@types/pluralize@0.0.29':
-    resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
 
   '@types/react-dom@19.2.5':
     resolution: {integrity: sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==}
@@ -1743,9 +1733,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@8.3.4':
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
   '@typescript-eslint/eslint-plugin@8.69.0':
     resolution: {integrity: sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==}
@@ -2163,9 +2150,6 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
-  charenc@0.0.2:
-    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -2281,9 +2265,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  crypt@0.0.2:
-    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
-
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -2294,10 +2275,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2427,6 +2404,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.52.0:
+    resolution: {integrity: sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==}
 
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
@@ -2728,10 +2708,6 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
-
   exsolve@1.1.1:
     resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
@@ -2877,10 +2853,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphql@15.10.3:
-    resolution: {integrity: sha512-e2ut+7oOFe5/jENYc+T7GZnL5lIBd7vcWg6TlqVx1L/MFXY3CKOsEcP+jMPgL8uwcfrllJRNSmqq5psZahdKZg==}
-    engines: {node: '>= 10.x'}
-
   graphql@16.14.2:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
@@ -2953,9 +2925,6 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
@@ -3191,9 +3160,6 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -3231,9 +3197,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  md5@2.3.0:
-    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -3412,6 +3375,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  mutative@1.3.0:
+    resolution: {integrity: sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ==}
+    engines: {node: '>=14.0'}
 
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
@@ -4008,9 +3975,6 @@ packages:
       vite-plus:
         optional: true
 
-  strict-event-emitter@0.2.8:
-    resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
-
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -4337,11 +4301,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -5163,27 +5122,13 @@ snapshots:
     dependencies:
       '@mjackson/headers': 0.5.1
 
-  '@mswjs/data@https://codeload.github.com/noveogroup-amorgunov/mswjs-data/tar.gz/7bfd31dd673ad7c19bb3ef0c841a59787adb2adf(@types/node@26.4.0)(@typescript/typescript6@6.0.2)(supports-color@8.1.1)':
+  '@msw/data@1.1.8':
     dependencies:
-      '@types/lodash': 4.17.25
-      '@types/md5': 2.3.6
-      '@types/pluralize': 0.0.29
-      '@types/uuid': 8.3.4
-      date-fns: 2.30.0
-      debug: 4.4.3(supports-color@8.1.1)
-      graphql: 15.10.3
-      lodash: 4.18.1
-      md5: 2.3.0
+      '@standard-schema/spec': 1.1.0
+      es-toolkit: 1.52.0
+      mutative: 1.3.0
       outvariant: 1.4.3
-      pluralize: 8.0.0
-      strict-event-emitter: 0.2.8
-      uuid: 8.3.2
-    optionalDependencies:
-      msw: 2.15.0(@types/node@26.4.0)(@typescript/typescript6@6.0.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - typescript
+      rettime: 0.11.11
 
   '@mswjs/interceptors@0.41.9':
     dependencies:
@@ -5848,10 +5793,6 @@ snapshots:
 
   '@types/katex@0.16.8': {}
 
-  '@types/lodash@4.17.25': {}
-
-  '@types/md5@2.3.6': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -5863,8 +5804,6 @@ snapshots:
   '@types/node@26.4.0':
     dependencies:
       undici-types: 8.3.0
-
-  '@types/pluralize@0.0.29': {}
 
   '@types/react-dom@19.2.5(@types/react@19.2.18)':
     dependencies:
@@ -5885,8 +5824,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@8.3.4': {}
 
   '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(@typescript/typescript6@6.0.2)(eslint@10.9.1(supports-color@8.1.1))(supports-color@8.1.1))(@typescript/typescript6@6.0.2)(eslint@10.9.1(supports-color@8.1.1))':
     dependencies:
@@ -6257,8 +6194,6 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  charenc@0.0.2: {}
-
   check-error@2.1.3: {}
 
   chokidar@4.0.3:
@@ -6354,17 +6289,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  crypt@0.0.2: {}
-
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
-
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -6472,6 +6401,8 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-errors@1.3.0: {}
+
+  es-toolkit@1.52.0: {}
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -6932,8 +6863,6 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  events@3.3.0: {}
-
   exsolve@1.1.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -7058,8 +6987,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@15.10.3: {}
-
   graphql@16.14.2: {}
 
   has-flag@4.0.0: {}
@@ -7111,8 +7038,6 @@ snapshots:
   interpret@3.1.1: {}
 
   is-arrayish@0.2.1: {}
-
-  is-buffer@1.1.6: {}
 
   is-builtin-module@5.0.0:
     dependencies:
@@ -7304,8 +7229,6 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
-  lodash@4.18.1: {}
-
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -7345,12 +7268,6 @@ snapshots:
       web-worker: 1.5.0
 
   markdown-table@3.0.4: {}
-
-  md5@2.3.0:
-    dependencies:
-      charenc: 0.0.2
-      crypt: 0.0.2
-      is-buffer: 1.1.6
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -7741,6 +7658,8 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - '@types/node'
+
+  mutative@1.3.0: {}
 
   mute-stream@3.0.0: {}
 
@@ -8386,10 +8305,6 @@ snapshots:
       - react
       - utf-8-validate
 
-  strict-event-emitter@0.2.8:
-    dependencies:
-      events: 3.3.0
-
   strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
@@ -8749,8 +8664,6 @@ snapshots:
       react: 19.2.8
 
   util-deprecate@1.0.2: {}
-
-  uuid@8.3.2: {}
 
   valibot@1.2.0(@typescript/typescript6@6.0.2):
     optionalDependencies:

--- a/src/app/apiMockWorker.ts
+++ b/src/app/apiMockWorker.ts
@@ -28,9 +28,11 @@ const apiMockWorker = setupWorker(
   ...userHandlers,
 )
 
-__serverStartDatabaseMigration()
-
 export async function startApiMockWorker() {
+  const shouldReset = Object.fromEntries(new URLSearchParams(document.location.search)).reset === '1'
+
+  await __serverStartDatabaseMigration(shouldReset)
+
   await apiMockWorker.start({
     onUnhandledRequest(request, print) {
       const url = new URL(request.url)

--- a/src/entities/cart/api/__mocks__/cartHandlers.ts
+++ b/src/entities/cart/api/__mocks__/cartHandlers.ts
@@ -9,23 +9,18 @@ export const cartHandlers = [
     try {
       const { userId } = await verifyAccessToken(parseTokenFromRequest(request))
 
-      const maybeCart = __serverDatabase.cart.findFirst({
-        where: {
-          user: {
-            id: { equals: userId },
-          },
-        },
-      })
+      const maybeCart = __serverDatabase.cart.findFirst(q =>
+        q.where({ user: { id: userId } }),
+      )
 
       if (!maybeCart) {
         return HttpResponse.json('Bad request', { status: 400 })
       }
 
-      const products = __serverDatabase.product.findMany({
-        where: {
-          id: { in: maybeCart.itemsProductId ?? [] },
-        },
-      })
+      const productIds = maybeCart.itemsProductId
+      const products = __serverDatabase.product.findMany(q =>
+        q.where({ id: id => productIds.includes(id) }),
+      )
 
       await delay(env.VITE_API_DELAY)
 
@@ -45,20 +40,20 @@ export const cartHandlers = [
       const apiDelay = url.searchParams.get('delay')
       const body = await request.json()
 
-      __serverDatabase.cart.update({
-        where: {
-          user: {
-            id: { equals: userId },
+      await __serverDatabase.cart.update(
+        q => q.where({ user: { id: userId } }),
+        {
+          data(cart) {
+            cart.version = body.version
+            cart.itemsProductQuantity = body.items.map(
+              (item: CartItemDto) => item.quantity,
+            )
+            cart.itemsProductId = body.items.map(
+              (item: CartItemDto) => item.productId,
+            )
           },
         },
-        data: {
-          version: body.version,
-          itemsProductQuantity: body.items.map(
-            (item: CartItemDto) => item.quantity,
-          ),
-          itemsProductId: body.items.map((item: CartItemDto) => item.productId),
-        },
-      })
+      )
 
       await delay(Number(apiDelay) || env.VITE_API_DELAY)
 

--- a/src/entities/category/api/__mocks__/categoryHandlers.ts
+++ b/src/entities/category/api/__mocks__/categoryHandlers.ts
@@ -16,9 +16,9 @@ const productSortByCompareFunctionMap: Record<
 
 export const categoriesHandlers = [
   http.get(`${env.VITE_API_ENDPOINT}/categories/popular`, async () => {
-    const categories = __serverDatabase.category.findMany({
-      where: { popular: { equals: true } },
-    })
+    const categories = __serverDatabase.category.findMany(q =>
+      q.where({ popular: true }),
+    )
 
     await delay(env.VITE_API_DELAY)
 
@@ -31,9 +31,9 @@ export const categoriesHandlers = [
     const sortBy = url.searchParams.get('sortBy')
     const apiDelay = url.searchParams.get('delay')
 
-    const maybeCategory = __serverDatabase.category.findFirst({
-      where: { id: { equals: Number(id) } },
-    })
+    const maybeCategory = __serverDatabase.category.findFirst(q =>
+      q.where({ id: Number(id) }),
+    )
 
     if (!maybeCategory) {
       await delay(Number(apiDelay) || env.VITE_API_DELAY)
@@ -45,9 +45,9 @@ export const categoriesHandlers = [
       products: [],
     }
 
-    categoryDto.products = __serverDatabase.product.findMany({
-      where: { categoryId: { equals: maybeCategory.id } },
-    })
+    categoryDto.products = __serverDatabase.product.findMany(q =>
+      q.where({ categoryId: maybeCategory.id }),
+    )
 
     if (sortBy) {
       categoryDto.products = categoryDto.products.sort(

--- a/src/entities/product/api/__mocks__/productHandlers.ts
+++ b/src/entities/product/api/__mocks__/productHandlers.ts
@@ -5,10 +5,10 @@ import { __serverDatabase } from '@/shared/lib/server'
 export const productsHandlers = [
   http.get(`${env.VITE_API_ENDPOINT}/products`, async ({ request }) => {
     const url = new URL(request.url)
-    const productIds = url.searchParams.getAll('id')
-    const products = __serverDatabase.product.findMany({
-      where: { id: { in: productIds.map(Number) } },
-    })
+    const productIds = url.searchParams.getAll('id').map(Number)
+    const products = __serverDatabase.product.findMany(q =>
+      q.where({ id: id => productIds.includes(id) }),
+    )
 
     await delay(env.VITE_API_DELAY)
     return HttpResponse.json(products, { status: 200 })

--- a/src/entities/session/api/__mocks__/sessionHandlers.ts
+++ b/src/entities/session/api/__mocks__/sessionHandlers.ts
@@ -7,12 +7,9 @@ export const sessionHandlers = [
     const body = await request.json()
     const { email, password } = body
 
-    const maybeUser = __serverDatabase.user.findFirst({
-      where: {
-        email: { equals: email },
-        password: { equals: password },
-      },
-    })
+    const maybeUser = __serverDatabase.user.findFirst(q =>
+      q.where({ email, password }),
+    )
 
     if (!maybeUser) {
       await delay(env.VITE_API_DELAY)

--- a/src/entities/wishlist/api/__mocks__/wishlistHandlers.ts
+++ b/src/entities/wishlist/api/__mocks__/wishlistHandlers.ts
@@ -9,19 +9,14 @@ export const wishlistHandlers = [
       try {
         const { userId } = await verifyAccessToken(parseTokenFromRequest(request))
 
-        const maybeWishlist = __serverDatabase.wishlist.findFirst({
-          where: {
-            user: {
-              id: { equals: userId },
-            },
-          },
-        })
+        const maybeWishlist = __serverDatabase.wishlist.findFirst(q =>
+          q.where({ user: { id: userId } }),
+        )
 
-        const products = __serverDatabase.product.findMany({
-          where: {
-            id: { in: maybeWishlist?.productIds ?? [] },
-          },
-        })
+        const wishlistProductIds = maybeWishlist?.productIds ?? []
+        const products = __serverDatabase.product.findMany(q =>
+          q.where({ id: id => wishlistProductIds.includes(id) }),
+        )
 
         await delay(env.VITE_API_DELAY)
         return HttpResponse.json(products, { status: 200 })
@@ -43,16 +38,14 @@ export const wishlistHandlers = [
         const apiDelay = url.searchParams.get('delay')
         const body = await request.json()
 
-        __serverDatabase.wishlist.update({
-          where: {
-            user: {
-              id: { equals: userId },
+        await __serverDatabase.wishlist.update(
+          q => q.where({ user: { id: userId } }),
+          {
+            data(wishlist) {
+              wishlist.productIds = body
             },
           },
-          data: {
-            productIds: body,
-          },
-        })
+        )
 
         await delay(Number(apiDelay) || env.VITE_API_DELAY)
         return HttpResponse.json({}, { status: 200 })

--- a/src/pages/main/api/__mocks__/productPopularListHandlers.ts
+++ b/src/pages/main/api/__mocks__/productPopularListHandlers.ts
@@ -4,9 +4,9 @@ import { __serverDatabase } from '@/shared/lib/server'
 
 export const productPopularListHandlers = [
   http.get(`${env.VITE_API_ENDPOINT}/products/popular`, async () => {
-    const products = __serverDatabase.product.findMany({
-      where: { popular: { equals: true } },
-    })
+    const products = __serverDatabase.product.findMany(q =>
+      q.where({ popular: true }),
+    )
 
     await delay(env.VITE_API_DELAY)
     return HttpResponse.json(

--- a/src/pages/product/api/__mocks__/productDetailsHandlers.ts
+++ b/src/pages/product/api/__mocks__/productDetailsHandlers.ts
@@ -6,9 +6,9 @@ export const productDetailsHandlers = [
   http.get(`${env.VITE_API_ENDPOINT}/products/:id`, async ({ params }) => {
     const { id } = params
 
-    const maybeProduct = __serverDatabase.product.findFirst({
-      where: { id: { equals: Number(id) } },
-    })
+    const maybeProduct = __serverDatabase.product.findFirst(q =>
+      q.where({ id: Number(id) }),
+    )
 
     await delay(env.VITE_API_DELAY)
     return HttpResponse.json(

--- a/src/shared/lib/server/migration.ts
+++ b/src/shared/lib/server/migration.ts
@@ -1,7 +1,7 @@
 import { env } from '@/shared/lib'
 import categoriesMock from './__mocks__/categories.json'
 import productsMock from './__mocks__/products.json'
-import { db } from './serverDb'
+import { db, dbHydration } from './serverDb'
 
 type CreateUserParams = {
   email: string
@@ -16,16 +16,16 @@ function generateId(tableName: string) {
   return idCounters[tableName]++
 }
 
-function createUser(userData: CreateUserParams) {
-  const user = db.user.create({ ...userData, id: generateId('user') })
+async function createUser(userData: CreateUserParams) {
+  const user = await db.user.create({ ...userData, id: generateId('user') })
 
-  db.wishlist.create({
+  await db.wishlist.create({
     id: generateId('wishlist'),
     user,
     productIds: [3, 4, 5, 6, 7],
   })
 
-  db.cart.create({
+  await db.cart.create({
     id: generateId('cart'),
     user,
     version: 0,
@@ -34,22 +34,37 @@ function createUser(userData: CreateUserParams) {
   })
 }
 
-export function startDatabaseMigration() {
-  const users = db.user.getAll()
+export async function startDatabaseMigration(shouldReset: boolean) {
+  // Wait until all the collections are hydrated from the storage
+  await dbHydration
 
-  // Data already exists by persist(db)
-  if (users.length > 0) {
+  if (shouldReset) {
+    db.cart.clear()
+    db.user.clear()
+    db.wishlist.clear()
+    db.product.clear()
+    db.category.clear()
+  }
+
+  const usersCount = db.user.count()
+
+  // Data already exists by the persist extension
+  if (usersCount > 0) {
     return
   }
 
   // create test users
-  createUser({
+  await createUser({
     email: env.VITE_API_USER_EMAIL,
     password: env.VITE_API_USER_PASSWORD,
   })
-  createUser({ email: 'test@ya.ru', password: '123456' })
+  await createUser({ email: 'test@ya.ru', password: '123456' })
 
-  categoriesMock.forEach(row => db.category.create(row))
+  for (const row of categoriesMock) {
+    await db.category.create(row)
+  }
 
-  productsMock.forEach(row => db.product.create(row))
+  for (const row of productsMock) {
+    await db.product.create(row)
+  }
 }

--- a/src/shared/lib/server/persistExtension.ts
+++ b/src/shared/lib/server/persistExtension.ts
@@ -1,0 +1,154 @@
+import { defineExtension } from '@msw/data/extensions'
+import type { Extension } from '@msw/data/extensions'
+import {
+  createFromSerializedRecord,
+  serializeRecord,
+} from '@msw/data/extensions/persist'
+import type { SerializedRecord } from '@msw/data/extensions/persist'
+
+const STORAGE_KEY = 'msw/data/storage'
+const STORAGE_VERSION = 2
+
+/**
+ * Storage key prefix of the custom persist extension
+ * from the legacy "@mswjs/data" fork.
+ * @see https://github.com/noveogroup-amorgunov/mswjs-data/tree/feat-persist
+ */
+const LEGACY_STORAGE_KEY_PREFIX = 'mswjs-data/'
+
+let isLegacyStorageCleanedUp = false
+
+function cleanupLegacyStorage() {
+  if (isLegacyStorageCleanedUp || typeof window === 'undefined') {
+    return
+  }
+  isLegacyStorageCleanedUp = true
+
+  for (const storage of [localStorage, sessionStorage]) {
+    for (const key of Object.keys(storage)) {
+      if (key.startsWith(LEGACY_STORAGE_KEY_PREFIX)) {
+        storage.removeItem(key)
+      }
+    }
+  }
+}
+
+type SerializedCollection = {
+  version: number
+  records: Array<SerializedRecord>
+}
+
+export type PersistExtensionOptions = {
+  /**
+   * Unique name of the collection, used as a part of the storage key.
+   */
+  name: string
+  /**
+   * Storage implementation, e.g. `localStorage` or `sessionStorage`.
+   */
+  storage: Storage
+}
+
+export type PersistExtensionResult = {
+  extension: Extension
+  /**
+   * Resolves when the collection is hydrated from the storage.
+   * Await it before reading or seeding the collection.
+   *
+   * @note This is a getter, because the actual hydration promise is
+   * assigned later, when the collection constructor applies the extension.
+   */
+  readonly hydration: Promise<void>
+}
+
+/**
+ * Custom version of the `@msw/data/extensions/persist` extension.
+ * Unlike the upstream one, allows to configure the storage
+ * (localStorage vs sessionStorage) and uses a predictable storage key.
+ *
+ * @see https://github.com/mswjs/data/issues/343
+ */
+export function persist(
+  options: PersistExtensionOptions,
+): PersistExtensionResult {
+  let hydration: Promise<void> = Promise.resolve()
+
+  const extension = defineExtension({
+    name: `persist:${options.name}`,
+    extend(collection) {
+      if (typeof window === 'undefined') {
+        return
+      }
+
+      cleanupLegacyStorage()
+
+      const collectionKey = `${STORAGE_KEY}/${options.name}`
+
+      /**
+       * Flush the collection whenever the page becomes hidden.
+       * This covers reloads, navigations, and closing the page.
+       */
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState !== 'hidden') {
+          return
+        }
+
+        options.storage.setItem(
+          collectionKey,
+          JSON.stringify({
+            version: STORAGE_VERSION,
+            records: collection.all().map(serializeRecord),
+          } satisfies SerializedCollection),
+        )
+      })
+
+      const rawPersistedData = options.storage.getItem(collectionKey)
+
+      if (!rawPersistedData) {
+        return
+      }
+
+      hydration = new Promise<void>((resolve) => {
+        /**
+         * Defer the hydration by a macrotask so the relations
+         * defined right after the collection construction
+         * apply to the hydrated records.
+         */
+        setTimeout(() => {
+          const persistedData = JSON.parse(
+            rawPersistedData,
+          ) as SerializedCollection
+
+          if (persistedData.version !== STORAGE_VERSION) {
+            console.warn(
+              `[persist:${options.name}] Skipping hydration: persisted data version (${persistedData.version}) is incompatible with the current version (${STORAGE_VERSION})`,
+            )
+            resolve()
+            return
+          }
+
+          Promise.all(
+            persistedData.records.map(record =>
+              createFromSerializedRecord(collection, record),
+            ),
+          )
+            .then(() => resolve())
+            .catch((error) => {
+              console.error(
+                `[persist:${options.name}] Failed to hydrate the collection`,
+                error,
+              )
+              resolve()
+            })
+        }, 0)
+      })
+    },
+  })
+
+  return {
+    extension,
+    get hydration() {
+      return hydration
+    },
+  }
+}

--- a/src/shared/lib/server/serverDb.ts
+++ b/src/shared/lib/server/serverDb.ts
@@ -39,14 +39,14 @@ const productSchema = z.object({
   categoryId: z.number().optional(),
   popular: z.boolean(),
   name: z.string(),
-  description: z.string().nullish(),
+  description: z.string().default(''),
   badge: z.string(),
   subtitle: z.string(),
   price: z.number(),
   discountPrice: z.number(),
   inStock: z.boolean(),
   imageUrl: z.array(z.string()),
-  detailsImageUrl: z.array(z.string()).nullish(),
+  detailsImageUrl: z.array(z.string()).default([]),
 })
 
 const categorySchema = z.object({

--- a/src/shared/lib/server/serverDb.ts
+++ b/src/shared/lib/server/serverDb.ts
@@ -1,52 +1,115 @@
-import { factory, nullable, oneOf, persist, primaryKey } from '@mswjs/data'
+import { Collection } from '@msw/data'
+import { z } from 'zod'
 import { env } from '../env'
+import { persist } from './persistExtension'
 
 /**
- * Its database, which using only in @mswjs "server" handlers
+ * Its database, which using only in @msw "server" handlers
  * This handlers run in the browser (client side) and emulate
  * work with real API and database
  */
-export const db = factory({
-  user: {
-    id: primaryKey(Number),
-    email: String,
-    password: String,
-  },
-  wishlist: {
-    id: primaryKey(Number),
-    user: oneOf('user'),
-    productIds: (): number[] => [],
-  },
-  cart: {
-    id: primaryKey(Number),
-    user: oneOf('user'),
-    version: Number,
-    itemsProductId: (): number[] => [],
-    itemsProductQuantity: (): number[] => [],
-  },
-  product: {
-    id: primaryKey(Number),
-    categoryId: Number,
-    popular: Boolean,
-    name: String,
-    description: nullable(String),
-    badge: String,
-    subtitle: String,
-    price: Number,
-    discountPrice: Number,
-    inStock: Boolean,
-    imageUrl: (): string[] => [],
-    detailsImageUrl: nullable((): string[] => []),
-  },
-  category: {
-    id: primaryKey(Number),
-    popular: Boolean,
-    name: String,
-    imageUrl: (): string[] => [],
-  },
+
+const userSchema = z.object({
+  id: z.number(),
+  email: z.string(),
+  password: z.string(),
 })
 
-persist(db, {
-  storage:
-    env.VITE_API_STORAGE_MODE === 'local' ? localStorage : sessionStorage,
+const wishlistSchema = z.object({
+  id: z.number(),
+  get user() {
+    return userSchema
+  },
+  productIds: z.array(z.number()),
 })
+
+const cartSchema = z.object({
+  id: z.number(),
+  get user() {
+    return userSchema
+  },
+  version: z.number(),
+  itemsProductId: z.array(z.number()),
+  itemsProductQuantity: z.array(z.number()),
+})
+
+const productSchema = z.object({
+  id: z.number(),
+  // Products in the mock data may not belong to any category
+  categoryId: z.number().optional(),
+  popular: z.boolean(),
+  name: z.string(),
+  description: z.string().nullish(),
+  badge: z.string(),
+  subtitle: z.string(),
+  price: z.number(),
+  discountPrice: z.number(),
+  inStock: z.boolean(),
+  imageUrl: z.array(z.string()),
+  detailsImageUrl: z.array(z.string()).nullish(),
+})
+
+const categorySchema = z.object({
+  id: z.number(),
+  popular: z.boolean(),
+  name: z.string(),
+  imageUrl: z.array(z.string()),
+})
+
+const storage
+  = env.VITE_API_STORAGE_MODE === 'local' ? localStorage : sessionStorage
+
+const usersPersist = persist({ name: 'user', storage })
+const wishlistsPersist = persist({ name: 'wishlist', storage })
+const cartsPersist = persist({ name: 'cart', storage })
+const productsPersist = persist({ name: 'product', storage })
+const categoriesPersist = persist({ name: 'category', storage })
+
+const users = new Collection({
+  schema: userSchema,
+  extensions: [usersPersist.extension],
+})
+const wishlists = new Collection({
+  schema: wishlistSchema,
+  extensions: [wishlistsPersist.extension],
+})
+const carts = new Collection({
+  schema: cartSchema,
+  extensions: [cartsPersist.extension],
+})
+const products = new Collection({
+  schema: productSchema,
+  extensions: [productsPersist.extension],
+})
+const categories = new Collection({
+  schema: categorySchema,
+  extensions: [categoriesPersist.extension],
+})
+
+wishlists.defineRelations(({ one }) => ({
+  user: one(users),
+}))
+
+carts.defineRelations(({ one }) => ({
+  user: one(users),
+}))
+
+export const db = {
+  user: users,
+  wishlist: wishlists,
+  cart: carts,
+  product: products,
+  category: categories,
+}
+
+/**
+ * Resolves when all the collections are hydrated from the storage.
+ * Await it before reading or seeding the database.
+ */
+export const dbHydration = Promise.all([
+  usersPersist.hydration,
+  wishlistsPersist.hydration,
+  cartsPersist.hydration,
+  productsPersist.hydration,
+  categoriesPersist.hydration,
+]).then(() => undefined)


### PR DESCRIPTION
## Why

- The `@mswjs/data` fork (`feat-persist` branch) is no longer needed: the official persist extension with fixed relational hydration landed in `@msw/data` v1.1.8 (mswjs/data#343, fixed by mswjs/data#377)
- Staying on the fork blocked dependency updates and diverged from the upstream API

## What has changed

- Replace the forked `@mswjs/data` with the official `@msw/data` v1.1.8; rewrite `serverDb` to `Collection` + zod schemas with `defineRelations`
- Add a custom persist extension (`src/shared/lib/server/persistExtension.ts`) with configurable storage (`VITE_API_STORAGE_MODE`), legacy `mswjs-data/*` storage keys cleanup and a fix for the stale `hydration` promise (getter instead of a snapshot)
- Expose `dbHydration` and await the database migration before starting the MSW worker
- Update all mock handlers (7 files) to the new query syntax (`q.where` predicates, async `create`/`update`)
- Add schema defaults for optional product mock fields (`description`, `detailsImageUrl`) to keep the `ProductDetailsDto` contract