### PR TITLE
chore: add AI skills (feature-sliced-design, code-review)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ src/shared/lib/env--compiled.mjs
 *.sln
 *.sw?
 debug-storybook.log
+
+# AI skills (installed from skills-lock.json via `pnpm setup`)
+.agents/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test:env": "./.scripts/validateEnv.sh",
+    "setup": "npx skills experimental_install",
     "prestart": "npm run test:env",
     "preinstall": "npx only-allow pnpm",
     "start": "vite",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "code-review": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/code-review/SKILL.md",
+      "computedHash": "caa9a086baaf9e0f7cd71f64edfa83da6821c05e826b083221f3d02e3d6a1905"
+    },
+    "feature-sliced-design": {
+      "source": "feature-sliced/skills",
+      "sourceType": "github",
+      "skillPath": "feature-sliced-design/SKILL.md",
+      "computedHash": "775a8ee42f32b12d33478eaf2416c0c1c394fac61b98805c6cf0f228cc2c9b34"
+    }
+  }
+}


### PR DESCRIPTION
## Why

- Provide AI agents with project-specific skills: FSD conventions and code review guidelines
- Keep the skills reproducible across machines with a lock file

## What has changed

- Pin `feature-sliced-design` (feature-sliced/skills) and `code-review` (mattpocock/skills) in `skills-lock.json`
- Ignore the installed skill files (`.agents/`) in `.gitignore`
- Add the `setup` script that restores the pinned skills via `npx skills experimental_install`