### PR TITLE
refactor: attach api access token without linking session store to shared layer

### DIFF
--- a/src/app/appEntry.tsx
+++ b/src/app/appEntry.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { Provider as ModalProvider } from '@ebay/nice-modal-react'
 import ReactDOM from 'react-dom/client'
 import { Provider as ReduxProvider } from 'react-redux'
+import { selectAccessToken } from '@/entities/session'
 import { ThemeProvider } from '@/entities/theme'
+import { setApiAccessToken } from '@/shared/api'
 import '@/shared/base.css'
 import { appStore } from '@/shared/redux'
 import { DebugModeProvider } from '@/widgets/Layout'
@@ -24,6 +26,27 @@ async function initApp() {
   const module = await import('@/app/apiMockWorker')
   await module.startApiMockWorker()
 }
+
+/**
+ * ✅ FSD Best practice
+ *
+ * Attach api access token to `@/shared/api/baseQuery.ts`
+ * without direct using session redux-slice in shared layer
+ * see previous version for details:
+ * @see https://github.com/noveogroup-amorgunov/nukeapp/blob/v0.0.1/src/shared/api/baseQuery.ts#L19
+ *
+ * ⚠️ `redux-remember` rehydration dispatch bypasses redux middleware chain,
+ * so `@/entities/session` `accessTokenSyncMiddleware` can't catch it.
+ * Sync token via store subscription instead,
+ * it fires synchronously on rehydration, before the first api request.
+ * @see https://github.com/zewish/redux-remember/blob/v6.0.2/src/rehydrate.ts#L44
+ */
+function syncApiAccessToken() {
+  setApiAccessToken(selectAccessToken(appStore.getState()) ?? null)
+}
+
+syncApiAccessToken()
+appStore.subscribe(syncApiAccessToken)
 
 initApp().then(() => {
   ReactDOM.createRoot(root).render(

--- a/src/entities/session/index.ts
+++ b/src/entities/session/index.ts
@@ -1,11 +1,13 @@
 import { sessionSlice } from './model/slice'
 
 export { sessionApi } from './api/sessionApi'
+export { accessTokenSyncMiddleware } from './model/accessTokenSyncMiddleware'
 export { sessionSlice } from './model/slice'
 
 export const {
   isAuthorized: selectIsAuthorized,
   userId: selectUserId,
+  accessToken: selectAccessToken,
 } = sessionSlice.selectors
 
 export const resetSessionData = sessionSlice.actions.reset

--- a/src/entities/session/model/accessTokenSyncMiddleware.ts
+++ b/src/entities/session/model/accessTokenSyncMiddleware.ts
@@ -1,0 +1,25 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit'
+import { setApiAccessToken } from '@/shared/api'
+import type { AppDispatch, AppState } from '@/shared/redux'
+import { dynamicMiddleware } from '@/shared/redux'
+import { sessionSlice } from './slice'
+
+/**
+ * Sync access token from session slice to `@/shared/api/baseQuery.ts`
+ */
+export const accessTokenSyncMiddleware
+  = createListenerMiddleware<AppState, AppDispatch>()
+
+accessTokenSyncMiddleware.startListening({
+  predicate: (_, currentState, previousState) => {
+    return (
+      sessionSlice.selectors.accessToken(currentState)
+      !== sessionSlice.selectors.accessToken(previousState)
+    )
+  },
+  effect: (_, api) => {
+    setApiAccessToken(sessionSlice.selectors.accessToken(api.getState()) ?? null)
+  },
+})
+
+dynamicMiddleware.addMiddleware(accessTokenSyncMiddleware.middleware)

--- a/src/entities/session/model/slice.ts
+++ b/src/entities/session/model/slice.ts
@@ -26,6 +26,7 @@ const slice = createSlice({
   selectors: {
     isAuthorized: state => state.isAuthorized,
     userId: state => state.userId,
+    accessToken: state => state.accessToken,
   },
   reducers: {
     reset: (state) => {

--- a/src/shared/api/apiAccessTokenMemoryStorage.ts
+++ b/src/shared/api/apiAccessTokenMemoryStorage.ts
@@ -1,0 +1,11 @@
+// Internal api access token storage
+// Updated via middleware in `@/entities/session`
+let __internalAccessToken: string | null = null
+
+export function setApiAccessToken(accessToken: string | null) {
+  __internalAccessToken = accessToken
+}
+
+export function getApiAccessToken() {
+  return __internalAccessToken
+}

--- a/src/shared/api/baseQuery.ts
+++ b/src/shared/api/baseQuery.ts
@@ -6,7 +6,7 @@ import type {
 } from '@reduxjs/toolkit/query'
 import { fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { env } from '../lib/env'
-import type { AppState } from '../redux'
+import { getApiAccessToken } from './apiAccessTokenMemoryStorage'
 
 export const baseQuery: BaseQueryFn<
   string | FetchArgs,
@@ -16,9 +16,8 @@ export const baseQuery: BaseQueryFn<
   FetchBaseQueryMeta
 > = fetchBaseQuery({
   baseUrl: env.VITE_API_ENDPOINT,
-  prepareHeaders: (headers, { getState }) => {
-    // FIXME: Attach access token to api without linking to session store
-    const accessToken = (getState() as AppState).session?.accessToken
+  prepareHeaders: (headers) => {
+    const accessToken = getApiAccessToken()
 
     if (accessToken) {
       headers.set('Authorization', `Bearer ${accessToken}`)

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,4 +1,5 @@
 export { apiAccessTokenIsBrokenEvent } from './apiAccessTokenIsBrokenEvent'
+export { getApiAccessToken, setApiAccessToken } from './apiAccessTokenMemoryStorage'
 export { baseApi } from './baseApi'
 export { isFetchBaseQueryError } from './isFetchBaseQueryError'
 export { CART_TAG, SESSION_TAG, USER_TAG, WISHLIST_TAG } from './tags'


### PR DESCRIPTION
## Why

- Removes the FSD violation from `src/shared/api/baseQuery.ts` where `prepareHeaders` read the access token directly from the session store (`(getState() as AppState).session?.accessToken`)
- Replaces the approach of the draft #37 (one-shot `attachApiAccessToken(getter)` in `appEntry`) with a token sync that reacts to **every** `accessToken` change

## What has changed

- `src/shared/api/apiAccessTokenMemoryStorage.ts` — in-memory token storage (`setApiAccessToken` / `getApiAccessToken`), used by `baseQuery` in `prepareHeaders`
- `src/entities/session/model/accessTokenSyncMiddleware.ts` — listener middleware in the session entity that syncs the token into the storage on every change (login, logout/reset, future refresh-token). Self-registers via `dynamicMiddleware` (same pattern as `logoutMiddleware`), so it also works for storybook stores (`makeStore({ persisted: false })`)
- `src/app/appEntry.tsx` — synchronous `syncApiAccessToken()` + `appStore.subscribe(syncApiAccessToken)`

### ⚠️ Why the store subscription in `appEntry` is required

`redux-remember` rehydrates state by dispatching `REMEMBER_REHYDRATED` through the inner (raw) store dispatch, **bypassing the whole redux middleware chain** — the listener middleware never fires on rehydration, the first request goes out without a token, gets 401 and logs the user out. Verified empirically. The store subscription fires synchronously on rehydration, before the first API request.

Supersedes and closes the draft #37.