### PR TITLE
docs: record raw item triage status as YAML frontmatter

### DIFF
--- a/docs/agents/development-workflow.md
+++ b/docs/agents/development-workflow.md
@@ -68,6 +68,15 @@ raw incoming (.scratch/) → /triage
   `/tdd`.
 - Small single-session work still gets a change directory, but any of the
   middle steps can be trivially short.
+- Raw incoming items in `.scratch/` carry their triage status in a YAML
+  frontmatter block at the top of the item file (matching the ADR metadata
+  format):
+
+```yaml
+---
+status: needs-triage
+---
+```
 
 ## Scenarios
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -10,8 +10,8 @@ directory under `docs/changes/` (see `development-workflow.md`).
 - One item per directory: `.scratch/<slug>/`
 - A raw incoming item is a short markdown file with whatever context the reporter
   left; no required format
-- Triage state is recorded as a `Status:` line near the top of each item file
-  (see `triage-labels.md` for the role strings)
+- Triage state is recorded in a YAML frontmatter block at the top of each item
+  file (`status:` key, see `triage-labels.md` for the role strings)
 - Wayfinder maps live at `.scratch/<effort>/map.md` with child decision tickets at
   `.scratch/<effort>/issues/NN-<slug>.md` (numbered from `01`, one file per ticket)
 - Research artifacts from `/research` also land in `.scratch/`


### PR DESCRIPTION
## Why

- Raw incoming items in `.scratch/` recorded their triage status as a plain `Status:` line, inconsistent with the ADR metadata format

## What has changed

- `docs/agents/development-workflow.md`: document that raw incoming items carry their triage status in a YAML frontmatter block (`status:` key)
- `docs/agents/issue-tracker.md`: update the raw item convention accordingly