### PR TITLE
chore(figma-skill): render text blocks through the Text component in design-to-code

### DIFF
--- a/.agents/skills/figma/references/design-to-code.md
+++ b/.agents/skills/figma/references/design-to-code.md
@@ -105,6 +105,11 @@ HTML/layout wrappers only for structures that are genuinely page composition
 rather than registered reusable components. Prefer semantic markup and project
 conventions.
 
+Render every text block through the `Text` component with the variant matching
+the Figma text style (font size/weight/line-height pick the variant). When no
+variant matches, style it in the CSS module like the mapped components do and
+note the gap in the `*.figma.yml` — same treatment as a missing token.
+
 ### 7. Translate layout semantically
 
 Do not mechanically translate Figma Auto Layout to `display:flex` or Figma


### PR DESCRIPTION
## Why

- The design-to-code workflow lacked an explicit rule for text rendering, so agents could hand-roll font styles in CSS instead of using the shared `Text` component.

## What has changed

- The `design-to-code` reference of the `figma` skill (step "Implement page composition") now requires every text block to render through `Text` with the variant matching the Figma text style; when no variant matches, style in the CSS module and note the gap in the `*.figma.yml` (same treatment as a missing token).